### PR TITLE
Add Canvas connection validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ venv.bak/
 frontend/build/
 frontend/dist/
 extension/dist/
+extension/.test-build/
 
 # Environment variables
 .env

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ A simple web app that fetches Canvas assignments and lets you schedule them in G
 2. Enter Canvas URL (e.g., `https://your-university.instructure.com`)
 3. Browse assignments and add to Google Calendar
 
+## Chrome Extension Permissions
+
+The Chrome extension stores the Canvas URL and API token in `chrome.storage.local`. Host access is optional: when `Test connection` is clicked, Chrome requests permission only for the exact HTTPS Canvas origin entered. That permission lets the extension call `GET /api/v1/users/self` with the local token; assignment fetching is not implemented yet.
+
 ## Tech Stack
 
 - **Frontend**: React + TypeScript + Tailwind CSS

--- a/extension/package.json
+++ b/extension/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "test:build": "tsc -p tsconfig.test.json",
+    "test": "pnpm run test:build && node --test test/*.test.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -17,5 +17,5 @@
     "alarms",
     "notifications"
   ],
-  "host_permissions": ["https://*.instructure.com/*"]
+  "optional_host_permissions": ["https://*/*"]
 }

--- a/extension/src/lib/canvas.ts
+++ b/extension/src/lib/canvas.ts
@@ -1,5 +1,31 @@
 import type { CanvasSettings, Course } from '../types';
 
+export interface CanvasConnectionProfile {
+  id: number;
+  name: string;
+  email?: string;
+}
+
+export type CanvasConnectionErrorCode =
+  | 'invalid-url'
+  | 'missing-token'
+  | 'network'
+  | 'unauthorized'
+  | 'missing-permissions'
+  | 'unexpected-response';
+
+export class CanvasConnectionError extends Error {
+  readonly code: CanvasConnectionErrorCode;
+  readonly status?: number;
+
+  constructor(code: CanvasConnectionErrorCode, message: string, status?: number) {
+    super(message);
+    this.name = 'CanvasConnectionError';
+    this.code = code;
+    this.status = status;
+  }
+}
+
 export const CANVAS_API_PATHS = {
   self: '/api/v1/users/self',
   courses: '/api/v1/courses',
@@ -18,16 +44,37 @@ export const DEFAULT_ASSIGNMENT_PARAMS = {
 
 export type CanvasQueryParams = Record<string, boolean | number | string>;
 
-export function normalizeCanvasUrl(rawUrl: string): string {
-  const trimmedUrl = rawUrl.trim();
+export function normalizeCanvasBaseUrl(input: string): string {
+  const trimmedUrl = input.trim();
   if (!trimmedUrl) {
-    return '';
+    throw new CanvasConnectionError('invalid-url', 'Enter a Canvas URL.');
   }
 
-  const urlWithProtocol = /^https?:\/\//i.test(trimmedUrl) ? trimmedUrl : `https://${trimmedUrl}`;
+  const urlWithProtocol = /^[a-z][a-z\d+.-]*:\/\//i.test(trimmedUrl)
+    ? trimmedUrl
+    : `https://${trimmedUrl}`;
 
+  let url: URL;
   try {
-    return new URL(urlWithProtocol).origin;
+    url = new URL(urlWithProtocol);
+  } catch {
+    throw new CanvasConnectionError('invalid-url', 'Enter a valid Canvas URL.');
+  }
+
+  if (url.protocol !== 'https:') {
+    throw new CanvasConnectionError('invalid-url', 'Canvas URL must start with https://.');
+  }
+
+  if (!url.hostname || url.username || url.password) {
+    throw new CanvasConnectionError('invalid-url', 'Enter a valid Canvas URL.');
+  }
+
+  return url.origin;
+}
+
+export function normalizeCanvasUrl(rawUrl: string): string {
+  try {
+    return normalizeCanvasBaseUrl(rawUrl);
   } catch {
     return '';
   }
@@ -42,10 +89,7 @@ export function buildCanvasApiUrl(
   apiPath: string,
   params: CanvasQueryParams = {},
 ): string {
-  const normalizedCanvasUrl = normalizeCanvasUrl(canvasUrl);
-  if (!normalizedCanvasUrl) {
-    throw new Error('Canvas URL is required.');
-  }
+  const normalizedCanvasUrl = normalizeCanvasBaseUrl(canvasUrl);
 
   const url = new URL(apiPath, `${normalizedCanvasUrl}/`);
 
@@ -59,7 +103,7 @@ export function buildCanvasApiUrl(
 export function buildCanvasHeaders(canvasToken: string): HeadersInit {
   const token = canvasToken.trim();
   if (!token) {
-    throw new Error('Canvas API token is required.');
+    throw new CanvasConnectionError('missing-token', 'Enter a Canvas API token.');
   }
 
   return {
@@ -72,4 +116,79 @@ export function buildCanvasRequest(settings: CanvasSettings, apiPath: string, pa
   return new Request(buildCanvasApiUrl(settings.canvasUrl, apiPath, params), {
     headers: buildCanvasHeaders(settings.canvasToken),
   });
+}
+
+export async function validateCanvasConnection(
+  settings: CanvasSettings,
+  fetchImpl: typeof fetch = fetch,
+): Promise<CanvasConnectionProfile> {
+  const requestUrl = buildCanvasApiUrl(settings.canvasUrl, CANVAS_API_PATHS.self);
+  const headers = buildCanvasHeaders(settings.canvasToken);
+
+  let response: Response;
+  try {
+    response = await fetchImpl(requestUrl, {
+      method: 'GET',
+      headers,
+    });
+  } catch {
+    throw new CanvasConnectionError(
+      'network',
+      'Unable to reach Canvas. Check the URL and your network connection.',
+    );
+  }
+
+  if (response.status === 401) {
+    throw new CanvasConnectionError(
+      'unauthorized',
+      'Canvas rejected the API token. Check that it was copied correctly.',
+      response.status,
+    );
+  }
+
+  if (response.status === 403) {
+    throw new CanvasConnectionError(
+      'missing-permissions',
+      'Canvas denied access. Create a token that can read your Canvas account.',
+      response.status,
+    );
+  }
+
+  if (!response.ok) {
+    throw new CanvasConnectionError(
+      'unexpected-response',
+      `Canvas returned an unexpected response (HTTP ${response.status}). Check that the URL points to your Canvas site.`,
+      response.status,
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new CanvasConnectionError('unexpected-response', 'Canvas returned a response that could not be read.');
+  }
+
+  return parseCanvasSelf(payload);
+}
+
+function parseCanvasSelf(payload: unknown): CanvasConnectionProfile {
+  if (!isRecord(payload) || typeof payload.id !== 'number' || typeof payload.name !== 'string') {
+    throw new CanvasConnectionError('unexpected-response', 'Canvas returned an unexpected user profile.');
+  }
+
+  const name = payload.name.trim();
+  if (!name) {
+    throw new CanvasConnectionError('unexpected-response', 'Canvas returned an unexpected user profile.');
+  }
+
+  return {
+    id: payload.id,
+    name,
+    ...(typeof payload.email === 'string' && payload.email.trim() ? { email: payload.email.trim() } : {}),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
 }

--- a/extension/src/lib/permissions.ts
+++ b/extension/src/lib/permissions.ts
@@ -1,0 +1,74 @@
+import { normalizeCanvasBaseUrl } from './canvas';
+
+export class CanvasHostPermissionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CanvasHostPermissionError';
+  }
+}
+
+export async function ensureCanvasHostPermission(canvasUrl: string): Promise<void> {
+  const permission = buildCanvasHostPermission(canvasUrl);
+
+  if (await hasPermission(permission)) {
+    return;
+  }
+
+  const granted = await requestPermission(permission);
+  if (!granted) {
+    throw new CanvasHostPermissionError(
+      'Chrome needs permission to contact this Canvas site before testing the connection.',
+    );
+  }
+}
+
+function buildCanvasHostPermission(canvasUrl: string): chrome.permissions.Permissions {
+  const origin = normalizeCanvasBaseUrl(canvasUrl);
+
+  // Host access stays optional: Chrome prompts for only the Canvas origin entered here.
+  return {
+    origins: [`${origin}/*`],
+  };
+}
+
+function getChromePermissions(): typeof chrome.permissions {
+  if (typeof chrome === 'undefined' || !chrome.permissions) {
+    throw new CanvasHostPermissionError(
+      'Open these settings from the installed Chrome extension before testing the connection.',
+    );
+  }
+
+  return chrome.permissions;
+}
+
+function hasPermission(permission: chrome.permissions.Permissions): Promise<boolean> {
+  const permissions = getChromePermissions();
+
+  return new Promise((resolve, reject) => {
+    permissions.contains(permission, (hasHostPermission) => {
+      const error = chrome.runtime.lastError;
+      if (error) {
+        reject(new CanvasHostPermissionError('Chrome could not check access to this Canvas site.'));
+        return;
+      }
+
+      resolve(hasHostPermission);
+    });
+  });
+}
+
+function requestPermission(permission: chrome.permissions.Permissions): Promise<boolean> {
+  const permissions = getChromePermissions();
+
+  return new Promise((resolve, reject) => {
+    permissions.request(permission, (granted) => {
+      const error = chrome.runtime.lastError;
+      if (error) {
+        reject(new CanvasHostPermissionError('Chrome could not request access to this Canvas site.'));
+        return;
+      }
+
+      resolve(granted);
+    });
+  });
+}

--- a/extension/src/options/OptionsPage.tsx
+++ b/extension/src/options/OptionsPage.tsx
@@ -1,12 +1,15 @@
 import { FormEvent, useEffect, useState } from 'react';
-import { normalizeCanvasUrl } from '../lib/canvas';
+import { normalizeCanvasBaseUrl, validateCanvasConnection } from '../lib/canvas';
+import { ensureCanvasHostPermission } from '../lib/permissions';
 import { getSettings, saveSettings } from '../lib/storage';
 import type { CanvasSettings } from '../types';
 
 type SaveStatus =
   | { state: 'idle'; message: '' }
   | { state: 'saving'; message: 'Saving settings...' }
+  | { state: 'testing'; message: 'Testing connection...' }
   | { state: 'saved'; message: 'Settings saved locally.' }
+  | { state: 'connected'; message: string }
   | { state: 'error'; message: string };
 
 const EMPTY_STATUS: SaveStatus = { state: 'idle', message: '' };
@@ -17,6 +20,9 @@ export function OptionsPage() {
     canvasToken: '',
   });
   const [status, setStatus] = useState<SaveStatus>(EMPTY_STATUS);
+  const isSaving = status.state === 'saving';
+  const isTesting = status.state === 'testing';
+  const isBusy = isSaving || isTesting;
 
   useEffect(() => {
     let isMounted = true;
@@ -43,14 +49,21 @@ export function OptionsPage() {
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const canvasUrl = normalizeCanvasUrl(settings.canvasUrl);
-    const canvasToken = settings.canvasToken.trim();
+    let canvasUrl: string;
 
-    if (!canvasUrl || !canvasToken) {
+    try {
+      canvasUrl = normalizeCanvasBaseUrl(settings.canvasUrl);
+    } catch (error) {
       setStatus({
         state: 'error',
-        message: 'Enter both a Canvas URL and API token.',
+        message: getErrorMessage(error, 'Enter a valid Canvas URL.'),
       });
+      return;
+    }
+
+    const canvasToken = settings.canvasToken.trim();
+    if (!canvasToken) {
+      setStatus({ state: 'error', message: 'Enter a Canvas API token.' });
       return;
     }
 
@@ -64,6 +77,41 @@ export function OptionsPage() {
       setStatus({
         state: 'error',
         message: error instanceof Error ? error.message : 'Unable to save settings.',
+      });
+    }
+  };
+
+  const handleTestConnection = async () => {
+    let canvasUrl: string;
+
+    try {
+      canvasUrl = normalizeCanvasBaseUrl(settings.canvasUrl);
+    } catch (error) {
+      setStatus({
+        state: 'error',
+        message: getErrorMessage(error, 'Enter a valid Canvas URL.'),
+      });
+      return;
+    }
+
+    const canvasToken = settings.canvasToken.trim();
+    if (!canvasToken) {
+      setStatus({ state: 'error', message: 'Enter a Canvas API token.' });
+      return;
+    }
+
+    setStatus({ state: 'testing', message: 'Testing connection...' });
+
+    try {
+      await ensureCanvasHostPermission(canvasUrl);
+      const user = await validateCanvasConnection({ canvasUrl, canvasToken });
+
+      setSettings({ canvasUrl, canvasToken });
+      setStatus({ state: 'connected', message: `Connected as ${user.name}` });
+    } catch (error) {
+      setStatus({
+        state: 'error',
+        message: getErrorMessage(error, 'Unable to test the Canvas connection.'),
       });
     }
   };
@@ -83,7 +131,8 @@ export function OptionsPage() {
           <label>
             <span>Canvas URL</span>
             <input
-              type="url"
+              type="text"
+              inputMode="url"
               value={settings.canvasUrl}
               onChange={(event) => setSettings((current) => ({ ...current, canvasUrl: event.target.value }))}
               placeholder="https://your-school.instructure.com"
@@ -104,9 +153,15 @@ export function OptionsPage() {
             />
           </label>
 
-          <button type="submit" disabled={status.state === 'saving'}>
-            {status.state === 'saving' ? 'Saving...' : 'Save settings'}
-          </button>
+          <div className="settings-actions">
+            <button type="submit" disabled={isBusy}>
+              {isSaving ? 'Saving...' : 'Save settings'}
+            </button>
+
+            <button type="button" className="secondary-button" onClick={handleTestConnection} disabled={isBusy}>
+              {isTesting ? 'Testing...' : 'Test connection'}
+            </button>
+          </div>
         </form>
 
         {status.message && (
@@ -117,4 +172,8 @@ export function OptionsPage() {
       </section>
     </main>
   );
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
 }

--- a/extension/src/styles.css
+++ b/extension/src/styles.css
@@ -145,8 +145,22 @@ h1 {
 }
 
 .settings-form button {
-  align-self: flex-start;
   min-width: 140px;
+}
+
+.settings-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.secondary-button {
+  background: #eef4f7;
+  color: #145a7a;
+}
+
+.secondary-button:hover {
+  background: #dbe9ef;
 }
 
 .status-message {
@@ -165,7 +179,13 @@ h1 {
   color: #195c36;
 }
 
+.status-connected {
+  background: #e8f3ed;
+  color: #195c36;
+}
+
 .status-saving,
+.status-testing,
 .status-idle {
   background: #eef4f7;
   color: #29485a;

--- a/extension/test/canvas.test.mjs
+++ b/extension/test/canvas.test.mjs
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  CanvasConnectionError,
+  normalizeCanvasBaseUrl,
+  normalizeCanvasUrl,
+  validateCanvasConnection,
+} from '../.test-build/lib/canvas.js';
+
+test('normalizeCanvasBaseUrl trims paths and adds https', () => {
+  assert.equal(
+    normalizeCanvasBaseUrl(' canvas.example.edu/courses/123?ignored=true '),
+    'https://canvas.example.edu',
+  );
+});
+
+test('normalizeCanvasBaseUrl rejects invalid or unsafe URLs', () => {
+  assertCanvasError(() => normalizeCanvasBaseUrl(''), 'invalid-url');
+  assertCanvasError(() => normalizeCanvasBaseUrl('http://canvas.example.edu'), 'invalid-url');
+  assertCanvasError(() => normalizeCanvasBaseUrl('https://token:secret@canvas.example.edu'), 'invalid-url');
+});
+
+test('normalizeCanvasUrl keeps the legacy empty-string fallback', () => {
+  assert.equal(normalizeCanvasUrl('not a valid host name'), '');
+});
+
+test('validateCanvasConnection returns the Canvas self profile', async () => {
+  const profile = await validateCanvasConnection(
+    {
+      canvasUrl: 'https://canvas.example.edu/accounts',
+      canvasToken: ' token-value ',
+    },
+    async (url, init) => {
+      assert.equal(url, 'https://canvas.example.edu/api/v1/users/self');
+      assert.equal(init.method, 'GET');
+      assert.equal(init.headers.Authorization, 'Bearer token-value');
+
+      return jsonResponse({ id: 42, name: 'Ada Lovelace', email: 'ada@example.edu' });
+    },
+  );
+
+  assert.deepEqual(profile, {
+    id: 42,
+    name: 'Ada Lovelace',
+    email: 'ada@example.edu',
+  });
+});
+
+test('validateCanvasConnection rejects missing tokens before fetch', async () => {
+  await assert.rejects(
+    validateCanvasConnection(
+      {
+        canvasUrl: 'https://canvas.example.edu',
+        canvasToken: ' ',
+      },
+      async () => {
+        throw new Error('fetch should not run');
+      },
+    ),
+    isCanvasError('missing-token'),
+  );
+});
+
+test('validateCanvasConnection maps network failures', async () => {
+  await assert.rejects(
+    validateCanvasConnection(
+      {
+        canvasUrl: 'https://canvas.example.edu',
+        canvasToken: 'token-value',
+      },
+      async () => {
+        throw new TypeError('failed to fetch');
+      },
+    ),
+    isCanvasError('network'),
+  );
+});
+
+test('validateCanvasConnection maps Canvas authentication and permission failures', async () => {
+  await assert.rejects(
+    validateCanvasConnection(
+      {
+        canvasUrl: 'https://canvas.example.edu',
+        canvasToken: 'bad-token',
+      },
+      async () => new Response('', { status: 401 }),
+    ),
+    isCanvasError('unauthorized'),
+  );
+
+  await assert.rejects(
+    validateCanvasConnection(
+      {
+        canvasUrl: 'https://canvas.example.edu',
+        canvasToken: 'limited-token',
+      },
+      async () => new Response('', { status: 403 }),
+    ),
+    isCanvasError('missing-permissions'),
+  );
+});
+
+test('validateCanvasConnection maps malformed Canvas responses', async () => {
+  await assert.rejects(
+    validateCanvasConnection(
+      {
+        canvasUrl: 'https://canvas.example.edu',
+        canvasToken: 'token-value',
+      },
+      async () => jsonResponse({ id: 42, display_name: 'Missing name' }),
+    ),
+    isCanvasError('unexpected-response'),
+  );
+});
+
+function jsonResponse(payload, init = {}) {
+  return new Response(JSON.stringify(payload), {
+    headers: {
+      'content-type': 'application/json',
+    },
+    status: 200,
+    ...init,
+  });
+}
+
+function assertCanvasError(callback, code) {
+  assert.throws(callback, isCanvasError(code));
+}
+
+function isCanvasError(code) {
+  return (error) => error instanceof CanvasConnectionError && error.code === code;
+}

--- a/extension/tsconfig.test.json
+++ b/extension/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "noEmit": false,
+    "outDir": ".test-build",
+    "rootDir": "src",
+    "sourceMap": false
+  },
+  "include": ["src/lib/canvas.ts", "src/types.ts"]
+}


### PR DESCRIPTION
- Added Canvas API connection validation through `/api/v1/users/self`
- Added URL normalization and friendly validation error handling
- Updated the settings page with a connection test flow
- Requested Canvas host permissions for the configured Canvas origin
- Kept Canvas credentials stored locally through extension storage